### PR TITLE
calculate number of fixed bits from input

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please refer to [Golomb-coded sets: smaller than Bloom filters](http://giovanni.
 API
 ---
 
-__`int golombset_encode(unsigned fixed_bits, const unsigned *keys, size_t num_keys, void *buf, size_t *bufsize);`__
+__`int golombset_encode(const unsigned *keys, size_t num_keys, void *buf, size_t *bufsize);`__
 
 The function encodes an pre-sorted array of keys into given buffer.
 
@@ -18,7 +18,7 @@ The function returns zero if successful, or -1 if otherwise (e.g. the size of th
 Upon calling the function the value of the pointer must specify the size of the buffer being supplied.
 When the function returns successfully, the value is updated the length of the bytes actually used to store the encoded data.
 
-__`int golombset_decode(unsigned fixed_bits, const void *buf, size_t bufsize, unsigned *keys, size_t *num_keys);`__
+__`int golombset_decode(const void *buf, size_t bufsize, unsigned *keys, size_t *num_keys);`__
 
 The function decodes the compressed data into an array of keys.
 

--- a/golombset.h
+++ b/golombset.h
@@ -22,18 +22,23 @@
 #ifndef GOLOMBSET_H
 #define GOLOMBSET_H
 
+#ifndef GOLOMBSET_FIXED_BITS_LENGTH
+#define GOLOMBSET_FIXED_BITS_LENGTH 5
+#endif
+#define GOLOMBSET_MAX_FIXED_BITS ((1 << (GOLOMBSET_FIXED_BITS_LENGTH)) - 1)
+
 struct st_golombset_encode_t {
-    const unsigned fixed_bits;
     unsigned char *dst;
     unsigned char *dst_max;
     unsigned dst_shift;
+    unsigned fixed_bits;
 };
 
 struct st_golombset_decode_t {
-    const unsigned fixed_bits;
     const unsigned char *src;
     const unsigned char *src_max;
     unsigned src_shift;
+    unsigned fixed_bits;
 };
 
 static int golombset_encode_bit(struct st_golombset_encode_t *ctx, int bit)
@@ -71,10 +76,10 @@ static int golombset_encode_value(struct st_golombset_encode_t *ctx, unsigned va
         return -1;
     /* emit the rest */
     unsigned shift = ctx->fixed_bits;
-    do {
+    while (shift != 0) {
         if (golombset_encode_bit(ctx, (value >> --shift) & 1) != 0)
             return -1;
-    } while (shift != 0);
+    }
 
     return 0;
 }
@@ -94,22 +99,46 @@ static int golombset_decode_value(struct st_golombset_decode_t *ctx, unsigned *v
     }
     /* decode the rest */
     unsigned shift = ctx->fixed_bits;
-    do {
+    while (shift != 0) {
         if ((bit = golombset_decode_bit(ctx)) == -1)
             return -1;
         *value |= bit << --shift;
-    } while (shift != 0);
+    }
 
     return 0;
 }
 
-static int golombset_encode(unsigned fixed_bits, const unsigned *keys, size_t num_keys, void *buf, size_t *bufsize)
+static unsigned golombset_calc_fixed_bits(unsigned max_key, size_t num_keys)
 {
-    struct st_golombset_encode_t ctx = {fixed_bits, buf, buf + *bufsize, 8};
+    unsigned delta, bits;
+
+    delta = max_key / num_keys;
+    if (delta <= 1)
+        return 0;
+    bits = sizeof(unsigned) * 8 - __builtin_clz(delta - 1);
+    if (bits > GOLOMBSET_MAX_FIXED_BITS)
+        bits = GOLOMBSET_MAX_FIXED_BITS;
+    return bits;
+}
+
+static int golombset_encode(const unsigned *keys, size_t num_keys, void *buf, size_t *bufsize)
+{
+    struct st_golombset_encode_t ctx = {buf, buf + *bufsize, 8};
     size_t i;
     unsigned next_min = 0;
 
-    *(unsigned char *)buf = 0xff;
+    if (num_keys == 0) {
+        *bufsize = 0;
+        return 0;
+    }
+
+    ctx.fixed_bits = golombset_calc_fixed_bits(keys[num_keys - 1], num_keys);
+
+    *(unsigned char *)ctx.dst = 0xff;
+    for (i = 0; i != GOLOMBSET_FIXED_BITS_LENGTH; ++i) {
+        if (golombset_encode_bit(&ctx, (ctx.fixed_bits >> (GOLOMBSET_FIXED_BITS_LENGTH - 1 - i)) & 1) != 0)
+            return -1;
+    }
     for (i = 0; i != num_keys; ++i) {
         if (golombset_encode_value(&ctx, keys[i] - next_min) != 0)
             return -1;
@@ -123,12 +152,23 @@ static int golombset_encode(unsigned fixed_bits, const unsigned *keys, size_t nu
     return 0;
 }
 
-static int golombset_decode(unsigned fixed_bits, const void *buf, size_t bufsize, unsigned *keys, size_t *num_keys)
+static int golombset_decode(const void *buf, size_t bufsize, unsigned *keys, size_t *num_keys)
 {
-    struct st_golombset_decode_t ctx = {fixed_bits, buf, buf + bufsize, 8};
-    size_t index = 0;
+    struct st_golombset_decode_t ctx = {buf, buf + bufsize, 8};
+    size_t i, index = 0;
     unsigned next_min = 0;
 
+    if (bufsize == 0) {
+        *num_keys = 0;
+        return 0;
+    }
+
+    for (i = 0; i != GOLOMBSET_FIXED_BITS_LENGTH; ++i) {
+        int bit = golombset_decode_bit(&ctx);
+        if (bit == -1)
+            return -1;
+        ctx.fixed_bits = (ctx.fixed_bits << 1) | bit;
+    }
     while (1) {
         unsigned value;
         if (golombset_decode_value(&ctx, &value) != 0)

--- a/test.c
+++ b/test.c
@@ -31,7 +31,7 @@ int main(int argc, char **argv)
     unsigned char buf[1024];
     size_t i, bufsize = sizeof(buf);
 
-    if (golombset_encode(6, keys, num_keys, buf, &bufsize) != 0) {
+    if (golombset_encode(keys, num_keys, buf, &bufsize) != 0) {
         fprintf(stderr, "golombset_encode failed\n");
         return 111;
     }
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
     
     unsigned decoded_keys[num_keys];
     size_t num_decoded_keys = num_keys;
-    if (golombset_decode(6, buf, bufsize, decoded_keys, &num_decoded_keys) != 0) {
+    if (golombset_decode(buf, bufsize, decoded_keys, &num_decoded_keys) != 0) {
         fprintf(stderr, "golombset_decode failed\n");
         return 111;
     }


### PR DESCRIPTION
This PR changes the behavior of the library to:
- calculate number of fixed bits from input,
- encode the number of fixed bits,
- use the encoded number when decoding,

instead of receiving the number as an argument to the codec.
